### PR TITLE
[autoupdate] Update ICU from "ICU 70.1" to "ICU 71.1"

### DIFF
--- a/actions/dependencies.sh
+++ b/actions/dependencies.sh
@@ -10,9 +10,9 @@ set -euxo pipefail
 # in actions/updatelib.py.
 
 # START DEPENDENCY-AUTOUPDATE SECTION
-ICU_NAME="ICU 70.1"
-ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-70-1/icu4c-70_1-Win64-MSVC2019.zip
-ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-70-1/icu4c-70_1-src.tgz
+ICU_NAME="ICU 71.1"
+ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-71-1/icu4c-71_1-Win64-MSVC2019.zip
+ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-71-1/icu4c-71_1-src.tgz
 JSON_VERSION=3.11.1
 JSON_URL=https://github.com/nlohmann/json/releases/download/v3.11.1/include.zip
 PYVERSIONS_WIN="3.6.7 3.7.9 3.8.10 3.9.13 3.10.8"


### PR DESCRIPTION
As of 2022-04-06T18:12:15Z, a new version of ICU has been released.

Release Information (sourced from https://github.com/unicode-org/icu/releases/tag/release-71-1)
<blockquote>

We are pleased to announce the release of Unicode® ICU 71.

ICU 71 updates to [CLDR 41](https://cldr.unicode.org/index/downloads/cldr-41) locale data with various additions and corrections.

ICU 71 adds phrase-based line breaking for Japanese. Existing line breaking methods follow standards and conventions for body text but do not work well for short Japanese text, such as in titles and headings. This new feature is optimized for these use cases.

ICU 71 adds support for Hindi written in Latin letters (`hi_Latn`). The CLDR data for this increasingly popular locale has been significantly revised and expanded. Note that based on user expectations, hi_Latn incorporates a large amount of English, and can also be referred to as “Hinglish”.

ICU 71 and CLDR 41 are minor releases, mostly focused on bug fixes and small enhancements. (The fall CLDR/ICU releases will update to Unicode 15 which is planned for September.) We are also working to re-establish continuous performance testing for ICU, and on development towards future versions.

ICU 71 updates to the time zone data version 2022a. Note that pre-1970 data for a number of time zones has been removed, as has been the case in the upstream [tzdata](https://www.iana.org/time-zones) release since 2021b.

For details, please see https://icu.unicode.org/download/71.
Note: Our website has moved. Please adjust your bookmarks.

The API reference documents are published at the following location: https://unicode-org.github.io/icu-docs/

*Note: The prebuilt WinARM64 binaries below should be considered alpha/experimental.*
</blockquote>

*I am a bot, and this action was performed automatically.*