### PR TITLE
[autoupdate] Update ICU from "ICU 71.1" to "ICU 72.1"

### DIFF
--- a/actions/dependencies.sh
+++ b/actions/dependencies.sh
@@ -10,9 +10,9 @@ set -euxo pipefail
 # in actions/updatelib.py.
 
 # START DEPENDENCY-AUTOUPDATE SECTION
-ICU_NAME="ICU 71.1"
-ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-71-1/icu4c-71_1-Win64-MSVC2019.zip
-ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-71-1/icu4c-71_1-src.tgz
+ICU_NAME="ICU 72.1"
+ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-72-1/icu4c-72_1-Win64-MSVC2019.zip
+ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-72-1/icu4c-72_1-src.tgz
 JSON_VERSION=3.11.2
 JSON_URL=https://github.com/nlohmann/json/releases/download/v3.11.2/include.zip
 PYVERSIONS_WIN="3.6.8 3.7.9 3.8.10 3.9.13 3.10.8"


### PR DESCRIPTION
As of 2022-10-18T20:23:16Z, a new version of ICU has been released.

Release Information (sourced from https://github.com/unicode-org/icu/releases/tag/release-72-1)
<blockquote>

We are pleased to announce the release of Unicode® ICU 72. It updates to [Unicode 15](https://blog.unicode.org/2022/09/announcing-unicode-standard-version-150.html), and to [CLDR 42](https://cldr.unicode.org/index/downloads/cldr-42) locale data with various additions and corrections.

ICU 72 and CLDR 42 are major releases, including a new version of Unicode and major locale data improvements. 

ICU 72 adds two technology preview implementations based on draft Unicode specifications:

* Formatting of people’s names in multiple languages ([CLDR background](https://cldr.unicode.org/index/downloads/cldr-42#h.nrv6xq99qe7d) on why this feature is being added and what it does)
* An enhanced version of message formatting

This release also updates to the time zone data version 2022e (2022-oct). Note that pre-1970 data for a number of time zones has been removed, as has been the case in the upstream [tzdata](https://www.iana.org/time-zones) release since 2021b.

For details, please see https://icu.unicode.org/download/72.

_Note: The prebuilt WinARM64 binaries below should be considered alpha/experimental._
</blockquote>

*I am a bot, and this action was performed automatically.*