### PR TITLE
[autoupdate] Update ICU from "ICU 74.2" to "ICU 75.1"

### DIFF
--- a/actions/build_macosuniversal.sh
+++ b/actions/build_macosuniversal.sh
@@ -21,7 +21,7 @@ if ! [ -f "$ICUDIR/iknow_icu_url.txt" ] || [ $(cat "$ICUDIR/iknow_icu_url.txt") 
   curl -L -o icu4c-src.tgz "$ICU_URL"
   tar xfz icu4c-src.tgz
   cd icu/source
-  CFLAGS="-arch x86_64 -arch arm64" CXXFLAGS="-std=c++11 -arch x86_64 -arch arm64" LDFLAGS=-headerpad_max_install_names ./runConfigureICU MacOSX --prefix="$ICUDIR"
+  CFLAGS="-arch x86_64 -arch arm64" CXXFLAGS="-std=c++17 -arch x86_64 -arch arm64" LDFLAGS=-headerpad_max_install_names ./runConfigureICU MacOSX --prefix="$ICUDIR"
   make -j $(sysctl -n hw.logicalcpu)
   make install
   echo "$ICU_URL" > "$ICUDIR/iknow_icu_url.txt"

--- a/actions/build_manylinux.sh
+++ b/actions/build_manylinux.sh
@@ -44,7 +44,7 @@ if ! [ -f "$ICUDIR/iknow_icu_url.txt" ] || [ $(cat "$ICUDIR/iknow_icu_url.txt") 
   curl -L -o icu4c-src.tgz "$ICU_URL"
   tar xfz icu4c-src.tgz
   cd icu/source
-  PYTHON=/opt/python/cp311-cp311/bin/python CXXFLAGS=-std=c++11 ./runConfigureICU Linux --prefix="$ICUDIR"
+  PYTHON=/opt/python/cp311-cp311/bin/python CXXFLAGS=-std=c++17 ./runConfigureICU Linux --prefix="$ICUDIR"
   make -j $(nproc)
   make install
   echo "$ICU_URL" > "$ICUDIR/iknow_icu_url.txt"

--- a/actions/dependencies.sh
+++ b/actions/dependencies.sh
@@ -10,9 +10,9 @@ set -euxo pipefail
 # in actions/updatelib.py.
 
 # START DEPENDENCY-AUTOUPDATE SECTION
-ICU_NAME="ICU 74.2"
-ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-74-2/icu4c-74_2-Win64-MSVC2019.zip
-ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-74-2/icu4c-74_2-src.tgz
+ICU_NAME="ICU 75.1"
+ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-75-1/icu4c-75_1-Win64-MSVC2022.zip
+ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-75-1/icu4c-75_1-src.tgz
 JSON_VERSION=3.11.3
 JSON_URL=https://github.com/nlohmann/json/releases/download/v3.11.3/include.zip
 PYVERSIONS_WIN="3.8.10 3.9.13 3.10.11 3.11.8 3.12.2"

--- a/build/make/platforms/dockerubuntux64.mak
+++ b/build/make/platforms/dockerubuntux64.mak
@@ -12,7 +12,7 @@ HEADERINCLUDEFLAG = -I
 OBJECTOUTPUTFLAG = -o
 OBJECTSUFFIX = .o
 LIBFLAGS = -fPIC
-OBJECTFLAGS += -c -O2 -DBIT64PLAT -DSIZEOF_LONG=8 -std=c++11 -Wno-deprecated-declarations -Wno-non-template-friend -DLINUX -DUNIX $(if $(CREATELIBRARY),$(LIBFLAGS))
+OBJECTFLAGS += -c -O2 -DBIT64PLAT -DSIZEOF_LONG=8 -std=c++17 -Wno-deprecated-declarations -Wno-non-template-friend -DLINUX -DUNIX $(if $(CREATELIBRARY),$(LIBFLAGS))
 
 ###Stage 2a: Objects->Library
 ifeq ($(USE_LIBRARIAN_LD),1)

--- a/build/make/platforms/lnxrharm64.mak
+++ b/build/make/platforms/lnxrharm64.mak
@@ -5,8 +5,8 @@
 MKDIR = test -e $(dir $@) || mkdir -p $(dir $@)
 DELETE = rm -f
 
-# Compile C++ code as C++11
-CPPLANGFLAG=-std=c++11
+# Compile C++ code as C++17
+CPPLANGFLAG=-std=c++17
 
 
 ###Stage 1: Source->Objects

--- a/build/make/platforms/lnxubuntuarm64.mak
+++ b/build/make/platforms/lnxubuntuarm64.mak
@@ -12,7 +12,7 @@ HEADERINCLUDEFLAG = -I
 OBJECTOUTPUTFLAG = -o
 OBJECTSUFFIX = .o
 LIBFLAGS = -fPIC
-OBJECTFLAGS += -c -O2 -DBIT64PLAT -DSIZEOF_LONG=8 -std=c++11 -Wno-deprecated-declarations -Wno-non-template-friend -DLINUX -DUNIX $(if $(CREATELIBRARY),$(LIBFLAGS))
+OBJECTFLAGS += -c -O2 -DBIT64PLAT -DSIZEOF_LONG=8 -std=c++17 -Wno-deprecated-declarations -Wno-non-template-friend -DLINUX -DUNIX $(if $(CREATELIBRARY),$(LIBFLAGS))
 
 ###Stage 2a: Objects->Library
 ifeq ($(USE_LIBRARIAN_LD),1)

--- a/build/make/platforms/lnxubuntuppc64le.mak
+++ b/build/make/platforms/lnxubuntuppc64le.mak
@@ -12,7 +12,7 @@ HEADERINCLUDEFLAG = -I
 OBJECTOUTPUTFLAG = -o
 OBJECTSUFFIX = .o
 LIBFLAGS = -fPIC
-OBJECTFLAGS += -c -O2 -std=c++1y -DBIT64PLAT -DSIZEOF_LONG=8 -std=c++11 -fsigned-char -Wno-unused-result -Wno-deprecated-declarations -Wno-non-template-friend -DLINUX -DUNIX $(if $(CREATELIBRARY),$(LIBFLAGS))
+OBJECTFLAGS += -c -O2 -DBIT64PLAT -DSIZEOF_LONG=8 -std=c++17 -fsigned-char -Wno-unused-result -Wno-deprecated-declarations -Wno-non-template-friend -DLINUX -DUNIX $(if $(CREATELIBRARY),$(LIBFLAGS))
 
 ###Stage 2a: Objects->Library
 ifeq ($(USE_LIBRARIAN_LD),1)

--- a/build/make/platforms/lnxubuntux64.mak
+++ b/build/make/platforms/lnxubuntux64.mak
@@ -7,7 +7,7 @@ DELETE = rm -f
 
 #CLANG_MODE = 1
 STDLIB=libc++
-CPPLANGFLAG=-std=c++11 -Wno-non-template-friend
+CPPLANGFLAG=-std=c++17 -Wno-non-template-friend
 
 ###Stage 1: Source->Objects
 ifeq ($(CLANG_MODE),1)

--- a/modules/aho/model0.mak
+++ b/modules/aho/model0.mak
@@ -9,7 +9,7 @@ PLATFORM = $(IKNOWPLAT)
 
 STRICT = 1
 
-CPP_LANGUAGE = 14
+CPP_LANGUAGE = 17
 
 INCLUDEDIRS = ./lexrep ./ali ./inl/$(IKNOWMODELLANG) . ../base/src/headers ../ali ../core/src/headers \
 	 $(ROOT_DIR)/shared/System/unix $(ROOT_DIR)/shared/System $(ROOT_DIR)/shared/Utility $(ICUDIR)/include $(ROOT_DIR)/kernel/common/h

--- a/modules/aho/model1.mak
+++ b/modules/aho/model1.mak
@@ -10,7 +10,7 @@ PLATFORM = $(IKNOWPLAT)
 
 STRICT = 1
 
-CPP_LANGUAGE = 14
+CPP_LANGUAGE = 17
 
 INCLUDEDIRS = ./inl/$(IKNOWMODELLANG)_regex ./lexrep ./ali . ../base/src/headers ../ali ../core/src/headers \
 	 $(ROOT_DIR)/shared/System/unix $(ROOT_DIR)/shared/System $(ROOT_DIR)/shared/Utility $(ICUDIR)/include $(ROOT_DIR)/kernel/common/h

--- a/modules/aho/model_common.mak
+++ b/modules/aho/model_common.mak
@@ -6,7 +6,7 @@ STRICT = 1
 #TODO: TRW - generalize!
 PLATFORM = $(IKNOWPLAT)
 
-CPP_LANGUAGE = 14
+CPP_LANGUAGE = 17
 INCLUDEDIRS =  $(ROOT_DIR)/modules/aho $(ROOT_DIR)/modules/base/src/headers $(ROOT_DIR)/modules/ali $(ROOT_DIR)/modules/core/src/headers \
 	 $(ROOT_DIR)/shared/System/unix $(ROOT_DIR)/shared/System $(ROOT_DIR)/shared/Utility $(ICUDIR)/include $(ROOT_DIR)/kernel/common/h
 

--- a/modules/ali/ali.mak
+++ b/modules/ali/ali.mak
@@ -6,7 +6,7 @@ PLATFORM = $(IKNOWPLAT)
 
 STRICT = 1
 
-CPP_LANGUAGE = 14
+CPP_LANGUAGE = 17
 
 INCLUDEDIRS = $(ROOT_DIR)/modules/ali $(ROOT_DIR)/shared/System $(ROOT_DIR)/shared/System/unix $(ROOT_DIR)/shared/Utility $(ROOT_DIR)/modules/base/src/headers $(ICUDIR)/include
 SOURCES = $(ROOT_DIR)/modules/ali/*.cpp

--- a/modules/base/base.mak
+++ b/modules/base/base.mak
@@ -6,7 +6,7 @@ PLATFORM = $(IKNOWPLAT)
 
 STRICT = 1
 
-CPP_LANGUAGE = 14
+CPP_LANGUAGE = 17
 
 INCLUDEDIRS = $(ROOT_DIR)/modules/base/src/headers $(ICUDIR)/include $(ROOT_DIR)/shared/System/unix $(ROOT_DIR)/shared/System $(ROOT_DIR)/shared/Utility $(ROOT_DIR)/kernel/common/h
 

--- a/modules/compiler/iKnowLanguageCompiler/languagecompiler.mak
+++ b/modules/compiler/iKnowLanguageCompiler/languagecompiler.mak
@@ -4,7 +4,7 @@ ROOT_DIR = $(realpath $(MAKEPATH)/../../..)
 #TODO: TRW - generalize!
 PLATFORM = $(IKNOWPLAT)
 
-CPP_LANGUAGE = 14
+CPP_LANGUAGE = 17
 
 INCLUDEDIRS = $(ROOT_DIR)/modules/shell/src $(ROOT_DIR)/modules/shell/src/SDK/headers $(ROOT_DIR)/modules/base/src/headers $(ROOT_DIR)/modules/core/src/headers $(ROOT_DIR)/shared/System/unix $(ROOT_DIR)/shared/System $(ROOT_DIR)/shared/Utility $(ROOT_DIR)/kernel/common/h $(ICUDIR)/include
 

--- a/modules/core/core.mak
+++ b/modules/core/core.mak
@@ -4,7 +4,7 @@ ROOT_DIR = $(realpath $(MAKEPATH)/../..)
 #TODO: TRW - generalize!
 PLATFORM = $(IKNOWPLAT)
 
-CPP_LANGUAGE = 14
+CPP_LANGUAGE = 17
 
 STRICT = 1
 

--- a/modules/engine/engine.mak
+++ b/modules/engine/engine.mak
@@ -4,7 +4,7 @@ ROOT_DIR = $(realpath $(MAKEPATH)/../..)
 #TODO: TRW - generalize!
 PLATFORM = $(IKNOWPLAT)
 
-CPP_LANGUAGE = 14
+CPP_LANGUAGE = 17
 
 INCLUDEDIRS = $(ROOT_DIR)/modules/engine/src $(ROOT_DIR)/modules/shell/src/SDK/headers $(ROOT_DIR)/modules/shell/src $(ROOT_DIR)/modules/ali $(ROOT_DIR)/modules/core/src/headers $(ROOT_DIR)/modules/base/src/headers $(ROOT_DIR)/modules/compiler/iKnowLanguageCompiler \
 	 $(ROOT_DIR)/kernel/$(PLATFORM)/h $(ROOT_DIR)/kernel/ux/h $(ROOT_DIR)/kernel/common/h $(ROOT_DIR)/shared/System/unix $(ROOT_DIR)/shared/System \

--- a/modules/enginetest/enginetest.mak
+++ b/modules/enginetest/enginetest.mak
@@ -4,7 +4,7 @@ ROOT_DIR = $(realpath $(MAKEPATH)/../..)
 #TODO: TRW - generalize!
 PLATFORM = $(IKNOWPLAT)
 
-CPP_LANGUAGE = 14
+CPP_LANGUAGE = 17
 
 INCLUDEDIRS = $(ROOT_DIR)/modules/shell/src $(ROOT_DIR)/modules/shell/src/SDK/headers $(ROOT_DIR)/modules/base/src/headers $(ROOT_DIR)/modules/ali $(ROOT_DIR)/modules/core/src/headers \
 			$(ROOT_DIR)/modules/aho $(ROOT_DIR)/modules/engine/src $(ROOT_DIR)/shared/System/unix $(ROOT_DIR)/shared/System $(ROOT_DIR)/shared/Utility \

--- a/modules/iKnowExplicitTest/engineloadtest.mak
+++ b/modules/iKnowExplicitTest/engineloadtest.mak
@@ -4,7 +4,7 @@ ROOT_DIR = $(realpath $(MAKEPATH)/../..)
 #TODO: TRW - generalize!
 PLATFORM = $(IKNOWPLAT)
 
-CPP_LANGUAGE = 14
+CPP_LANGUAGE = 17
 
 INCLUDEDIRS = $(ROOT_DIR)/modules/shell/src $(ROOT_DIR)/modules/shell/src/SDK/headers $(ROOT_DIR)/modules/base/src/headers $(ROOT_DIR)/modules/ali $(ROOT_DIR)/modules/core/src/headers $(ROOT_DIR)/modules/aho $(ROOT_DIR)/modules/engine/src $(ROOT_DIR)/shared/System/unix $(ROOT_DIR)/shared/System $(ROOT_DIR)/shared/Utility $(ROOT_DIR)/kernel/common/h $(ICUDIR)/include
 

--- a/modules/iknowpy/setup.py
+++ b/modules/iknowpy/setup.py
@@ -704,7 +704,7 @@ else:
         enginelibs_name_pattern = 'libiknow*.dylib'
         os.environ['CC'] = 'clang++'  # workaround to force setuptools to invoke C++ compiler
         os.environ['CXX'] = 'clang++'
-        extra_compile_args = ['-std=c++11']
+        extra_compile_args = ['-std=c++17']
         if sys.version_info[:2] == (3, 8):
             # workaround for https://github.com/cython/cython/issues/3474
             extra_compile_args.append('-Wno-deprecated-declarations')

--- a/modules/shell/shell.mak
+++ b/modules/shell/shell.mak
@@ -6,7 +6,7 @@ PLATFORM = $(IKNOWPLAT)
 
 STRICT = 1
 
-CPP_LANGUAGE = 14
+CPP_LANGUAGE = 17
 
 INCLUDEDIRS = $(ROOT_DIR)/modules/shell/src $(ROOT_DIR)/modules/shell/src/SDK/headers $(ROOT_DIR)/modules/base/src/headers $(ROOT_DIR)/modules/ali $(ROOT_DIR)/modules/core/src/headers $(ROOT_DIR)/modules/aho $(ROOT_DIR)/shared/System/unix $(ROOT_DIR)/shared/System $(ROOT_DIR)/shared/Utility $(ROOT_DIR)/kernel/common/h $(ICUDIR)/include
 


### PR DESCRIPTION
As of 2024-04-16T00:57:15Z, a new version of ICU has been released.

Release Information (sourced from https://github.com/unicode-org/icu/releases/tag/release-75-1)
<blockquote>

Unicode® ICU 75 updates to [CLDR 45](https://cldr.unicode.org/index/downloads/cldr-45) ([beta blog](https://blog.unicode.org/2024/04/unicode-cldr-v45-beta-available-for.html)) locale data with new locales and various additions and corrections. C++ code now requires C++17 and is being made more robust.

The CLDR MessageFormat 2.0 specification is now in [technology preview](https://github.com/unicode-org/message-format-wg?tab=readme-ov-file#messageformat-2-technical-preview), together with a corresponding update of the ICU4J (Java) tech preview and a new ICU4C (C++) tech preview.

For details, please see https://icu.unicode.org/download/75.
</blockquote>

*I am a bot, and this action was performed automatically.*