### PR TITLE
[autoupdate] Update ICU from "ICU 74.2" to "ICU 75.1"

### DIFF
--- a/actions/dependencies.sh
+++ b/actions/dependencies.sh
@@ -10,9 +10,9 @@ set -euxo pipefail
 # in actions/updatelib.py.
 
 # START DEPENDENCY-AUTOUPDATE SECTION
-ICU_NAME="ICU 74.2"
-ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-74-2/icu4c-74_2-Win64-MSVC2019.zip
-ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-74-2/icu4c-74_2-src.tgz
+ICU_NAME="ICU 75.1"
+ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-75-1/icu4c-75_1-Win64-MSVC2022.zip
+ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-75-1/icu4c-75_1-src.tgz
 JSON_VERSION=3.11.3
 JSON_URL=https://github.com/nlohmann/json/releases/download/v3.11.3/include.zip
 PYVERSIONS_WIN="3.8.10 3.9.13 3.10.11 3.11.9 3.12.5"


### PR DESCRIPTION
As of 2024-04-16T00:57:15Z, a new version of ICU has been released.

Release Information (sourced from https://github.com/unicode-org/icu/releases/tag/release-75-1)
<blockquote>

Unicode® ICU 75 updates to [CLDR 45](https://cldr.unicode.org/index/downloads/cldr-45) ([beta blog](https://blog.unicode.org/2024/04/unicode-cldr-v45-beta-available-for.html)) locale data with new locales and various additions and corrections. C++ code now requires C++17 and is being made more robust.

The CLDR MessageFormat 2.0 specification is now in [technology preview](https://github.com/unicode-org/message-format-wg?tab=readme-ov-file#messageformat-2-technical-preview), together with a corresponding update of the ICU4J (Java) tech preview and a new ICU4C (C++) tech preview.

For details, please see https://icu.unicode.org/download/75.
</blockquote>

*I am a bot, and this action was performed automatically.*